### PR TITLE
Disable informer initialization of devopsprojects

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -452,7 +452,6 @@ func (s *APIServer) waitForResourceSync(stopCh <-chan struct{}) error {
 		{Group: "iam.kubesphere.io", Version: "v1alpha2", Resource: "groups"},
 		{Group: "iam.kubesphere.io", Version: "v1alpha2", Resource: "groupbindings"},
 		{Group: "cluster.kubesphere.io", Version: "v1alpha1", Resource: "clusters"},
-		{Group: "devops.kubesphere.io", Version: "v1alpha3", Resource: "devopsprojects"},
 		{Group: "network.kubesphere.io", Version: "v1alpha1", Resource: "ippools"},
 		{Group: "notification.kubesphere.io", Version: "v2beta1", Resource: v2beta1.ResourcesPluralConfig},
 		{Group: "notification.kubesphere.io", Version: "v2beta1", Resource: v2beta1.ResourcesPluralReceiver},

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -215,7 +215,8 @@ func (s *APIServer) installKubeSphereAPIs() {
 		s.Config.AuthenticationOptions)
 	amOperator := am.NewOperator(s.KubernetesClient.KubeSphere(),
 		s.KubernetesClient.Kubernetes(),
-		s.InformerFactory)
+		s.InformerFactory,
+		s.Config)
 	rbacAuthorizer := rbac.NewRBACAuthorizer(amOperator)
 
 	urlruntime.Must(configv1alpha2.AddToContainer(s.container, s.Config))
@@ -344,7 +345,7 @@ func (s *APIServer) buildHandlerChain(stopCh <-chan struct{}) {
 	case authorizationoptions.RBAC:
 		excludedPaths := []string{"/oauth/*", "/kapis/config.kubesphere.io/*", "/kapis/version", "/kapis/metrics"}
 		pathAuthorizer, _ := path.NewAuthorizer(excludedPaths)
-		amOperator := am.NewReadOnlyOperator(s.InformerFactory)
+		amOperator := am.NewReadOnlyOperator(s.InformerFactory, s.Config)
 		authorizers = unionauthorizer.New(pathAuthorizer, rbac.NewRBACAuthorizer(amOperator))
 	}
 

--- a/pkg/apiserver/authorization/rbac/rbac_test.go
+++ b/pkg/apiserver/authorization/rbac/rbac_test.go
@@ -920,7 +920,7 @@ func newMockRBACAuthorizer(staticRoles *StaticRoles) (*RBACAuthorizer, error) {
 			return nil, err
 		}
 	}
-	return NewRBACAuthorizer(am.NewReadOnlyOperator(fakeInformerFactory)), nil
+	return NewRBACAuthorizer(am.NewReadOnlyOperator(fakeInformerFactory, nil)), nil
 }
 
 func TestAppliesTo(t *testing.T) {

--- a/pkg/models/iam/am/am.go
+++ b/pkg/models/iam/am/am.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"kubesphere.io/kubesphere/pkg/apiserver/config"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -112,7 +113,13 @@ type amOperator struct {
 	k8sclient                  kubernetes.Interface
 }
 
-func NewReadOnlyOperator(factory informers.InformerFactory) AccessManagementInterface {
+func NewReadOnlyOperator(factory informers.InformerFactory, config *config.Config) AccessManagementInterface {
+	// Make devops project lister initialize when devops.devopsServiceAddress has text
+	var devopsProjectLister devopslisters.DevOpsProjectLister = nil
+	if config != nil && len(config.DevopsOptions.DevOpsServiceAddress) > 0 {
+		devopsProjectLister = factory.KubeSphereSharedInformerFactory().Devops().V1alpha3().DevOpsProjects().Lister()
+	}
+
 	return &amOperator{
 		globalRoleBindingGetter:    globalrolebinding.New(factory.KubeSphereSharedInformerFactory()),
 		workspaceRoleBindingGetter: workspacerolebinding.New(factory.KubeSphereSharedInformerFactory()),
@@ -122,13 +129,13 @@ func NewReadOnlyOperator(factory informers.InformerFactory) AccessManagementInte
 		workspaceRoleGetter:        workspacerole.New(factory.KubeSphereSharedInformerFactory()),
 		clusterRoleGetter:          clusterrole.New(factory.KubernetesSharedInformerFactory()),
 		roleGetter:                 role.New(factory.KubernetesSharedInformerFactory()),
-		//devopsProjectLister:        factory.KubeSphereSharedInformerFactory().Devops().V1alpha3().DevOpsProjects().Lister(),
-		namespaceLister: factory.KubernetesSharedInformerFactory().Core().V1().Namespaces().Lister(),
+		devopsProjectLister:        devopsProjectLister,
+		namespaceLister:            factory.KubernetesSharedInformerFactory().Core().V1().Namespaces().Lister(),
 	}
 }
 
-func NewOperator(ksClient kubesphere.Interface, k8sClient kubernetes.Interface, factory informers.InformerFactory) AccessManagementInterface {
-	amOperator := NewReadOnlyOperator(factory).(*amOperator)
+func NewOperator(ksClient kubesphere.Interface, k8sClient kubernetes.Interface, factory informers.InformerFactory, config *config.Config) AccessManagementInterface {
+	amOperator := NewReadOnlyOperator(factory, config).(*amOperator)
 	amOperator.ksclient = ksClient
 	amOperator.k8sclient = k8sClient
 	return amOperator

--- a/pkg/models/iam/am/am.go
+++ b/pkg/models/iam/am/am.go
@@ -122,8 +122,8 @@ func NewReadOnlyOperator(factory informers.InformerFactory) AccessManagementInte
 		workspaceRoleGetter:        workspacerole.New(factory.KubeSphereSharedInformerFactory()),
 		clusterRoleGetter:          clusterrole.New(factory.KubernetesSharedInformerFactory()),
 		roleGetter:                 role.New(factory.KubernetesSharedInformerFactory()),
-		devopsProjectLister:        factory.KubeSphereSharedInformerFactory().Devops().V1alpha3().DevOpsProjects().Lister(),
-		namespaceLister:            factory.KubernetesSharedInformerFactory().Core().V1().Namespaces().Lister(),
+		//devopsProjectLister:        factory.KubeSphereSharedInformerFactory().Devops().V1alpha3().DevOpsProjects().Lister(),
+		namespaceLister: factory.KubernetesSharedInformerFactory().Core().V1().Namespaces().Lister(),
 	}
 }
 

--- a/pkg/models/iam/am/am.go
+++ b/pkg/models/iam/am/am.go
@@ -114,7 +114,8 @@ type amOperator struct {
 }
 
 func NewReadOnlyOperator(factory informers.InformerFactory, config *config.Config) AccessManagementInterface {
-	// Make devops project lister initialize when devops.devopsServiceAddress has text
+	// Make devops project lister initialize when devops.devopsServiceAddress is not empty.
+	// And we keep the DevOps related code lines until DevOps becomes a full independent project.
 	var devopsProjectLister devopslisters.DevOpsProjectLister = nil
 	if config != nil && len(config.DevopsOptions.DevOpsServiceAddress) > 0 {
 		devopsProjectLister = factory.KubeSphereSharedInformerFactory().Devops().V1alpha3().DevOpsProjects().Lister()

--- a/pkg/models/tenant/tenent_test.go
+++ b/pkg/models/tenant/tenent_test.go
@@ -541,7 +541,7 @@ func prepare() Interface {
 			RoleBindings().Informer().GetIndexer().Add(roleBinding)
 	}
 
-	amOperator := am.NewOperator(ksClient, k8sClient, fakeInformerFactory)
+	amOperator := am.NewOperator(ksClient, k8sClient, fakeInformerFactory, nil)
 	authorizer := rbac.NewRBACAuthorizer(amOperator)
 
 	return New(fakeInformerFactory, k8sClient, ksClient, nil, nil, nil, amOperator, authorizer, nil, nil)

--- a/pkg/simple/client/devops/jenkins/options.go
+++ b/pkg/simple/client/devops/jenkins/options.go
@@ -40,7 +40,7 @@ func NewDevopsOptions() *Options {
 		Username:       "",
 		Password:       "",
 		MaxConnections: 100,
-		Enable:         false,
+		Enable:         true,
 	}
 }
 

--- a/pkg/simple/client/devops/jenkins/options.go
+++ b/pkg/simple/client/devops/jenkins/options.go
@@ -40,7 +40,7 @@ func NewDevopsOptions() *Options {
 		Username:       "",
 		Password:       "",
 		MaxConnections: 100,
-		Enable:         true,
+		Enable:         false,
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:
Disable informer initialization of devopsprojects

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
