### PR TITLE
Refine jenkins option and check if devops plugin address config is configured

### DIFF
--- a/pkg/apiserver/filters/devops.go
+++ b/pkg/apiserver/filters/devops.go
@@ -33,8 +33,9 @@ import (
 
 // WithDevOpsAPIServer proxy request to DevOps service if requests path has the APIGroup with devops.kubesphere.io
 func WithDevOpsAPIServer(handler http.Handler, config *jenkins.Options, failed proxy.ErrorResponder) http.Handler {
-	if config.DevOpsServiceAddress == "" || config.K8sBearerToken == "" {
-		klog.V(6).Info("The DevOps service address or k8s token is empty, the proxy of DevOps server was not enabled")
+	if config.DevOpsServiceAddress == "" || config.DevOpsPluginServiceAddress == "" || config.K8sBearerToken == "" {
+		klog.V(6).Info("The DevOps service address, devops plugin service address or k8s token is empty," +
+			" the proxy of DevOps server was not enabled")
 		// this filter rely on a separate DevOps address
 		// do not pass the proxy if there's no service address
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -52,7 +53,7 @@ func WithDevOpsAPIServer(handler http.Handler, config *jenkins.Options, failed p
 
 		if info.APIGroup == "devops.kubesphere.io" {
 			serverAsProxy(w, req, config.DevOpsServiceAddress, config.K8sBearerToken)
-		} else  if info.APIGroup == "tenant.kubesphere.io" && info.Resource == "devops" {
+		} else if info.APIGroup == "tenant.kubesphere.io" && info.Resource == "devops" {
 			serverAsProxy(w, req, config.DevOpsPluginServiceAddress, config.K8sBearerToken)
 		} else {
 			handler.ServeHTTP(w, req)

--- a/pkg/simple/client/devops/jenkins/options.go
+++ b/pkg/simple/client/devops/jenkins/options.go
@@ -31,8 +31,7 @@ type Options struct {
 	MaxConnections             int    `json:"maxConnections,omitempty" yaml:"maxConnections" description:"Maximum connections allowed to connect to Jenkins"`
 	DevOpsServiceAddress       string `json:"devopsServiceAddress" yaml:"devopsServiceAddress" description:"The separate DevOps Service address"`
 	DevOpsPluginServiceAddress string `json:"devopsPluginServiceAddress" yaml:"devopsPluginServiceAddress" description:"The KubeSphere DevOps plugin Service address"`
-	// K8sBearerToken does not take input from outside
-	K8sBearerToken string
+	K8sBearerToken             string `json:"k8sBearerToken" yaml:"k8sBearerToken" description:"K8s bearer token does not take input from outside'"`
 }
 
 // NewDevopsOptions returns a `zero` instance


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind flake

**What this PR does / why we need it**:

- Add field annotation on `K8sBearerToken` field of Jenkins#Option.
- Check if devops plugin address config is configured as well.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
